### PR TITLE
Make dynamic loading not default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ This project is originally intended to serve rust tensor toolkit [RSTSR](https:/
 
 Motivation of this repository, is that we want some of the following features:
 
-- **Dynamic loading support**. We support either usual FFI (requires library linking) or dynamic loading (load library in runtime) by switching crate feature `dynamic_loading`. Dynamic loading scheme is the default.
+- **Dynamic loading support**. We support either usual FFI (requires library linking) or dynamic loading (load library in runtime) by switching crate feature `dynamic_loading`. Dynamic loading scheme is not the default, and should be enabled manually.
 - **Preprocessor directives support**. This is especially for `ILP64`, where integers can be `int`, `int32_t` or `int64_t`, which will also affect signature in FFI bindings.
 - **Utilities from BLAS distributions**. For example, To use BLAS with proper threading, we may need to use utilities that is written from BLAS distributions, instead of reference (netlib) BLAS.
 - **Additional BLAS extensions**. Many current BLAS implementations have some useful BLAS extensions (such as batched gemm, complex gemm3m, half-precision gemm, i/omatcopy, etc.). Some of these extensions may be essential (more than non-negligible) to efficiency (such as application in machine learning). However, it is difficult (or not very proper) to declare these BLAS extensions in one crate.

--- a/rstsr-aocl-ffi/Cargo.toml
+++ b/rstsr-aocl-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstsr-aocl-ffi"
-version = "0.1.1"
+version = "0.2.0"
 description = "Intel AMD Optimizing CPU Libraries FFI bindings"
 readme = "readme.md"
 
@@ -17,7 +17,7 @@ half = { workspace = true }
 num = { workspace = true }
 
 [features]
-default = ["blis", "lapack", "dynamic_loading"]
+default = ["blis", "lapack"]
 
 ilp64 = ["rstsr-cblas-base/ilp64"]
 lp64_as_int = ["rstsr-cblas-base/lp64_as_int"]

--- a/rstsr-aocl-ffi/readme.md
+++ b/rstsr-aocl-ffi/readme.md
@@ -17,9 +17,9 @@ This crate is not official bindgen project. It is originally intended to serve r
 
 ## Dynamic loading
 
-This crate supports dynamic loading by default.
+This crate supports dynamic loading.
 
-If you do not want to use dynamic loading, please disable default cargo features (`--no-default-features` when cargo build).
+If you want to use dynamic loading, please enable cargo feature `dynamic_loading` when cargo build.
 
 The dynamic loading will try to find proper library when your program initializes.
 - This crate will automatically detect proper libraries, if these libraries are in environmental path `LD_LIBRARY_PATH` (Linux) `DYLD_LIBRARY_PATH` (Mac OS), `PATH` (Windows).
@@ -39,12 +39,12 @@ debug = false
 
 Default features:
 
-- `dynamic_loading`: Supports dynamic loading.
 - `blis`: Include BLIS bindgens.
 - `flame`: Include LAPACK bindgens.
 
 Optional features:
 
+- `dynamic_loading`: Supports dynamic loading.
 - `ilp64`: Use `int64_t` for dimension specification, or lapack error code types if this feature specified. Otherwise, use `int32_t`.
     - Please note that in module `blas`, error code is returned by `c_int`; in module `cblas`, BLIS utility functions use `c_int` for input or output.
 
@@ -61,6 +61,10 @@ Optional features:
     - special case of `cblas::ffi_base`: the enums `CBLAS_TRANSPOSE`, `CBLAS_UPLO`, etc comes from crate `rstsr_lapack_ffi` for convenience. This crate depends on `rstsr_lapack_ffi` for those definitions of enums.
 
 ## Changelog
+
+- v0.2.0
+
+    - **API Breaking**: Now cargo feature `dynamic_loading` is not default.
 
 - v0.1.1
 

--- a/rstsr-blis-ffi/Cargo.toml
+++ b/rstsr-blis-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstsr-blis-ffi"
-version = "0.1.3"
+version = "0.2.0"
 description = "BLIS and FLAME FFI bindings"
 readme = "readme.md"
 
@@ -17,7 +17,7 @@ half = { workspace = true }
 num = { workspace = true }
 
 [features]
-default = ["lapack", "dynamic_loading", "x86_64"]
+default = ["lapack", "x86_64"]
 
 ilp64 = ["rstsr-cblas-base/ilp64"]
 lp64_as_int = ["rstsr-cblas-base/lp64_as_int"]

--- a/rstsr-blis-ffi/readme.md
+++ b/rstsr-blis-ffi/readme.md
@@ -31,9 +31,9 @@ LDFLAGS=-L<blis_dir> LIBS=-lblis ./configure --enable-dynamic-build --enable-lap
 
 ## Dynamic loading
 
-This crate supports dynamic loading by default.
+This crate supports dynamic loading.
 
-If you do not want to use dynamic loading, please disable default cargo features (`--no-default-features` when cargo build).
+If you want to use dynamic loading, please enable cargo feature `dynamic_loading` when cargo build.
 
 The dynamic loading will try to find proper library when your program initializes.
 - This crate will automatically detect proper libraries, if these libraries are in environmental path `LD_LIBRARY_PATH` (Linux) `DYLD_LIBRARY_PATH` (Mac OS), `PATH` (Windows).
@@ -53,12 +53,12 @@ debug = false
 
 Default features:
 
-- `dynamic_loading`: Supports dynamic loading.
 - `lapack`: Include LAPACK bindgens.
 - `x86_64`: Use bindgen generated from x86_64 (not necessarily meaning arm64 could not use most functions in x86_64 bindgen, but arm64 will not able to use much lower-level ASM functions).
 
 Optional features:
 
+- `dynamic_loading`: Supports dynamic loading.
 - `ilp64`: Use `int64_t` for dimension specification, or lapack error code types if this feature specified. Otherwise, use `int32_t`.
     - Please note that in module `blas`, error code is returned by `c_int`; in module `cblas`, BLIS utility functions use `c_int` for input or output.
 - `flame`: Include FLAME bindgens.
@@ -79,6 +79,10 @@ Mutually exclusive features:
     - special case of `cblas::ffi_base`: the enums `CBLAS_TRANSPOSE`, `CBLAS_UPLO`, etc comes from crate `rstsr_lapack_ffi` for convenience. This crate depends on `rstsr_lapack_ffi` for those definitions of enums.
 
 ## Changelog
+
+- v0.2.0
+
+    - **API Breaking**: Now cargo feature `dynamic_loading` is not default.
 
 - v0.1.3
 

--- a/rstsr-kml-ffi/Cargo.toml
+++ b/rstsr-kml-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstsr-kml-ffi"
-version = "0.1.0"
+version = "0.2.0"
 description = "Huawei Kunpeng Math Library FFI bindings"
 readme = "readme.md"
 
@@ -17,7 +17,7 @@ half = { workspace = true }
 num = { workspace = true }
 
 [features]
-default = ["blas", "kblas", "lapack", "dynamic_loading"]
+default = ["blas", "kblas", "lapack"]
 
 ilp64 = ["rstsr-cblas-base/ilp64"]
 lp64_as_int = ["rstsr-cblas-base/lp64_as_int"]

--- a/rstsr-kml-ffi/readme.md
+++ b/rstsr-kml-ffi/readme.md
@@ -13,9 +13,9 @@ This crate is not official bindgen project. It is originally intended to serve r
 
 ## Dynamic loading
 
-This crate supports dynamic loading by default.
+This crate supports dynamic loading.
 
-If you do not want to use dynamic loading, please disable default cargo features (`--no-default-features` when cargo build).
+If you want to use dynamic loading, please enable cargo feature `dynamic_loading` when cargo build.
 
 The dynamic loading will try to find proper library when your program initializes.
 - This crate will automatically detect proper libraries, if these libraries are in environmental path `LD_LIBRARY_PATH` (Linux) `DYLD_LIBRARY_PATH` (Mac OS), `PATH` (Windows).
@@ -35,13 +35,13 @@ debug = false
 
 Default features:
 
-- `dynamic_loading`: Supports dynamic loading.
 - `blas`: Inclulde BLAS bindgens.
 - `kblas`: Include KML CBLAS bindgens.
 - `lapack`: Include LAPACK bindgens.
 
 Optional features:
 
+- `dynamic_loading`: Supports dynamic loading.
 - `ilp64`: Use `int64_t` for dimension specification, or lapack error code types if this feature specified. Otherwise, use `int32_t`.
     - Please note that in module `blas`, error code is returned by `c_int`; in module `cblas`, KML utility functions use `c_int` for input or output.
 - `lapacke`: Include LAPACKE bindgens.
@@ -153,3 +153,9 @@ ${FC} -o ${LIBKLAPACK_FULL_SO} -shared -fPIC -Wl,--whole-archive ${LIBKLAPACK_A}
 </details>
 
 After `libklapack_full.so` generated, you may need to add the directory of both `libkblas.so` and `libklapack_full.so` to the environmental variable `LD_LIBRARY_PATH`, to let the crate rstsr-kml-ffi know where to find lapack functions.
+
+## Changelog
+
+- v0.2.0
+
+    - **API Breaking**: Now cargo feature `dynamic_loading` is not default.

--- a/rstsr-lapack-ffi/Cargo.toml
+++ b/rstsr-lapack-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstsr-lapack-ffi"
-version = "0.4.3"
+version = "0.5.0"
 description = "Netlib LAPACK FFI bindings"
 readme = "readme.md"
 
@@ -15,7 +15,7 @@ rstsr-cblas-base = { workspace = true }
 libloading = { workspace = true, optional = true }
 
 [features]
-default = ["blas", "cblas", "lapack", "dynamic_loading"]
+default = ["blas", "cblas", "lapack"]
 
 ilp64 = ["rstsr-cblas-base/ilp64"]
 lp64_as_int = ["rstsr-cblas-base/lp64_as_int"]

--- a/rstsr-lapack-ffi/readme.md
+++ b/rstsr-lapack-ffi/readme.md
@@ -13,9 +13,9 @@ This crate is not official bindgen project. It is originally intended to serve r
 
 ## Dynamic loading
 
-This crate supports dynamic loading by default.
+This crate supports dynamic loading.
 
-If you do not want to use dynamic loading, please disable default cargo features (`--no-default-features` when cargo build).
+If you want to use dynamic loading, please enable cargo feature `dynamic_loading` when cargo build.
 
 The dynamic loading will try to find proper library when your program initializes.
 - This crate will automatically detect proper libraries, if these libraries are in environmental path `LD_LIBRARY_PATH` (Linux) `DYLD_LIBRARY_PATH` (Mac OS), `PATH` (Windows).
@@ -37,13 +37,13 @@ debug = false
 
 Default features:
 
-- `dynamic_loading`: Supports dynamic loading.
 - `blas`: Inclulde BLAS bindgens.
 - `cblas`: Include CBLAS bindgens.
 - `lapack`: Include LAPACK bindgens.
 
 Optional features:
 
+- `dynamic_loading`: Supports dynamic loading.
 - `ilp64`: Use `int64_t` for dimension specification, or lapack error code types if this feature specified. Otherwise, use `int32_t`.
     - Please note that in LAPACKE, matrix layout (mostly the first argument in LAPACKE functions) is always `core::ffi::c_int`, dependent to c compiler.
 - `lapacke`: Include LAPACKE bindgens.
@@ -67,6 +67,10 @@ Optional features:
     - `dyload_compatible.rs`: Unsafe bindgen function that is compatible to that of `ffi_extern.rs`. Only activated when dynamic loading.
 
 ## Changelog
+
+- v0.5.0
+
+    - **API Breaking**: Now cargo feature `dynamic_loading` is not default.
 
 - v0.4.3
 

--- a/rstsr-mkl-ffi/Cargo.toml
+++ b/rstsr-mkl-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstsr-mkl-ffi"
-version = "0.1.5"
+version = "0.2.0"
 description = "Intel oneAPI MKL FFI bindings"
 readme = "readme.md"
 
@@ -17,7 +17,7 @@ half = { workspace = true }
 num = { workspace = true }
 
 [features]
-default = ["blas", "cblas", "lapack", "dynamic_loading"]
+default = ["blas", "cblas", "lapack"]
 
 ilp64 = ["rstsr-cblas-base/ilp64"]
 lp64_as_int = ["rstsr-cblas-base/lp64_as_int"]

--- a/rstsr-mkl-ffi/readme.md
+++ b/rstsr-mkl-ffi/readme.md
@@ -20,9 +20,9 @@ This crate is not official bindgen project. It is originally intended to serve r
 
 ## Dynamic loading
 
-This crate supports dynamic loading by default.
+This crate supports dynamic loading.
 
-If you do not want to use dynamic loading, please disable default cargo features (`--no-default-features` when cargo build).
+If you want to use dynamic loading, please enable cargo feature `dynamic_loading` when cargo build.
 
 The dynamic loading will try to find proper library when your program initializes.
 - This crate will automatically detect proper libraries (`libmkl_rt.so`), if these libraries are in environmental path `LD_LIBRARY_PATH` (Linux) `DYLD_LIBRARY_PATH` (Mac OS), `PATH` (Windows).
@@ -47,13 +47,13 @@ println!("cargo:rustc-link-arg=-Wl,--no-as-needed,-lm");
 
 Default features:
 
-- `dynamic_loading`: Supports dynamic loading.
 - `blas`: Inclulde BLAS bindgens.
 - `cblas`: Include CBLAS bindgens.
 - `lapack`: Include LAPACK bindgens.
 
 Optional features:
 
+- `dynamic_loading`: Supports dynamic loading.
 - `ilp64`: Use `int64_t` for dimension specification, or lapack error code types if this feature specified. Otherwise, use `int32_t`.
     - Please note that in module `blas`, error code is returned by `c_int`; in module `cblas`, oneAPI MKL utility functions use `c_int` for input or output.
 - `lapacke`: Include LAPACKE bindgens.
@@ -71,6 +71,10 @@ Optional features:
     - special case of `cblas::ffi_base`: the enums `CBLAS_TRANSPOSE`, `CBLAS_UPLO`, etc comes from crate `rstsr_lapack_ffi` for convenience. This crate depends on `rstsr_lapack_ffi` for those definitions of enums.
 
 ## Changelog
+
+- v0.2.0
+
+    - **API Breaking**: Now cargo feature `dynamic_loading` is not default.
 
 - v0.1.5
 

--- a/rstsr-openblas-ffi/Cargo.toml
+++ b/rstsr-openblas-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rstsr-openblas-ffi"
-version = "0.4.5"
+version = "0.5.0"
 description = "OpenBLAS FFI bindings"
 readme = "readme.md"
 
@@ -15,7 +15,7 @@ rstsr-cblas-base = { workspace = true }
 libloading = { workspace = true, optional = true }
 
 [features]
-default = ["blas", "cblas", "lapack", "dynamic_loading"]
+default = ["blas", "cblas", "lapack"]
 
 ilp64 = ["rstsr-cblas-base/ilp64"]
 lp64_as_int = ["rstsr-cblas-base/lp64_as_int"]

--- a/rstsr-openblas-ffi/readme.md
+++ b/rstsr-openblas-ffi/readme.md
@@ -13,9 +13,9 @@ This crate is not official bindgen project. It is originally intended to serve r
 
 ## Dynamic loading
 
-This crate supports dynamic loading by default.
+This crate supports dynamic loading.
 
-If you do not want to use dynamic loading, please disable default cargo features (`--no-default-features` when cargo build).
+If you want to use dynamic loading, please enable cargo feature `dynamic_loading` when cargo build.
 
 The dynamic loading will try to find proper library when your program initializes.
 - This crate will automatically detect proper libraries, if these libraries are in environmental path `LD_LIBRARY_PATH` (Linux) `DYLD_LIBRARY_PATH` (Mac OS), `PATH` (Windows).
@@ -35,13 +35,13 @@ debug = false
 
 Default features:
 
-- `dynamic_loading`: Supports dynamic loading.
 - `blas`: Inclulde BLAS bindgens.
 - `cblas`: Include CBLAS bindgens.
 - `lapack`: Include LAPACK bindgens.
 
 Optional features:
 
+- `dynamic_loading`: Supports dynamic loading.
 - `ilp64`: Use `int64_t` for dimension specification, or lapack error code types if this feature specified. Otherwise, use `int32_t`.
     - Please note that in module `blas`, error code is returned by `c_int`; in module `cblas`, OpenBLAS utility functions use `c_int` for input or output.
 - `lapacke`: Include LAPACKE bindgens.
@@ -63,6 +63,10 @@ Optional features:
     - special case of `cblas::ffi_base`: the enums `CBLAS_TRANSPOSE`, `CBLAS_UPLO`, etc comes from crate `rstsr_lapack_ffi` for convenience. This crate depends on `rstsr_lapack_ffi` for those definitions of enums.
 
 ## Changelog
+
+- v0.5.0
+
+    - **API Breaking**: Now cargo feature `dynamic_loading` is not default.
 
 - v0.4.5
 


### PR DESCRIPTION
This API breaking PR will remove cargo feature `dynamic_loading` from default for many crates.

Although dynamic loading have many benefits, and is the default feature of cudarc; however, enabling dynamic loading for LAPACK can hugely increase compile time and disk usage, if not configured properly.
This is mostly because LAPACK (and LAPACKE) is very large library, containing huge function signatures, comared to cudarc (cublas/cusolver about 500 functions per lib), ort (onnx about 350 functions).

Advice is: **Using conventional shared-library linking is more friendly to developers. Only use dynamic-loading if dynamic-loading when deploying and distributing to end-users.**

We revert to the status to not using dynamic loading by default.